### PR TITLE
feat: provide DeviceManager and change deviceManager implementation

### DIFF
--- a/frida/comp.go
+++ b/frida/comp.go
@@ -17,7 +17,7 @@ type Compiler struct {
 // NewCompiler creates new compiler.
 func NewCompiler() *Compiler {
 	mgr := getDeviceManager()
-	cc := C.frida_compiler_new(mgr.manager)
+	cc := C.frida_compiler_new(mgr.getManager())
 
 	return &Compiler{
 		cc: cc,

--- a/frida/device.go
+++ b/frida/device.go
@@ -62,10 +62,10 @@ func (d *Device) Bus() *Bus {
 }
 
 // Manager returns device manager for the device.
-func (d *Device) Manager() *DeviceManager {
+func (d *Device) Manager() DeviceManager {
 	if d.device != nil {
 		mgr := C.frida_device_get_manager(d.device)
-		return &DeviceManager{mgr}
+		return &deviceManager{mgr}
 	}
 	return nil
 }

--- a/frida/frida.go
+++ b/frida/frida.go
@@ -35,14 +35,14 @@ func Version() string {
 	return C.GoString(C.frida_version_string())
 }
 
-func getDeviceManager() *DeviceManager {
+func getDeviceManager() DeviceManager {
 	v, ok := data.Load("mgr")
 	if !ok {
 		mgr := NewDeviceManager()
 		data.Store("mgr", mgr)
 		return mgr
 	}
-	return v.(*DeviceManager)
+	return v.(DeviceManager)
 }
 
 // LocalDevice is a wrapper around DeviceByType(DeviceTypeLocal).


### PR DESCRIPTION
Similar #23 

However this method would switch over to only exposing the interface to the caller, ultimately abstracting away the implementation details. 

This would be a bit of a breaking change but this module is pre v1. I wanted to provide both approaches for this reason as it would be nice for unit testing/when a device is unavailable for use.

I personally would like to change all the GetDevice methods in the manager over to returning and interface of device to allow for mock ability there as well.

Let me know what you think.

Cheers! 