### PR TITLE
ci: add macos to examples test

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,13 +1,26 @@
 name: examples
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
 jobs:
-  linux:
+  examples:
     strategy:
+      fail-fast: false
       matrix:
-        arch: [x86_64]
-        os: [linux]
-        frida_version: ["16.0.13"]
-    runs-on: ubuntu-latest
+        include:
+          - runs_on: ubuntu-latest
+            arch: x86_64
+            os: linux
+            frida_version: "16.0.13"
+          - runs_on: macos-latest
+            arch: x86_64
+            os: macos
+            frida_version: "16.0.13"
+    runs-on: ${{ matrix.runs_on }}
     env:
       GODEBUG: cgocheck=2
     steps:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,11 @@
 name: linting
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
 jobs:
   staticcheck:
     strategy:


### PR DESCRIPTION
- Adds macos build to examples test
- Limits github action runs to only on PRs and on push to main (can remove if asked just wanted to save minutes when possible). At the very least I could change to not run the push workflow when a PR is open.