### PR TITLE
fix: use incompatible build types for darwin

### DIFF
--- a/frida/frida.go
+++ b/frida/frida.go
@@ -8,10 +8,11 @@ package frida
 
 /*
 #cgo LDFLAGS: -lfrida-core -lm -ldl
-#cgo CFLAGS: -I/usr/local/include/ -w -Wno-error=incompatible-function-pointer-types
+#cgo CFLAGS: -I/usr/local/include/ -w
 #cgo darwin LDFLAGS: -lbsm -framework Foundation -framework AppKit -lresolv -lpthread
+#cgo darwin CFLAGS: -Wno-error=incompatible-function-pointer-types
 #cgo android LDFLAGS: -llog
-#cgo android CFLAGS: -DANDROID
+#cgo android CFLAGS: -DANDROID -Wno-error=incompatible-function-pointer-types
 #cgo linux,!android LDFLAGS: -lrt -lresolv -lpthread
 #cgo linux CFLAGS: -pthread
 #include <frida-core.h>


### PR DESCRIPTION
I ran into this tonight. What is the reasoning for adding it to all build targets exactly?