### PR TITLE
Fix g_variant_get_fixed_array n_elements pointer reference

### DIFF
--- a/frida/variants_to_go.go
+++ b/frida/variants_to_go.go
@@ -53,7 +53,7 @@ static char* read_byte_array(GVariant *variant, int * n_elements)
 	guint8 * array = NULL;
 
 	array = g_variant_get_fixed_array (variant,
-									   (gsize)n_elements,
+									   (gsize *)&n_elements,
 									   sizeof(guint8));
 	return (char*)array;
 }

--- a/frida/variants_to_go.go
+++ b/frida/variants_to_go.go
@@ -53,7 +53,7 @@ static char* read_byte_array(GVariant *variant, int * n_elements)
 	guint8 * array = NULL;
 
 	array = g_variant_get_fixed_array (variant,
-									   (gsize *)&n_elements,
+									   (gsize *)n_elements,
 									   sizeof(guint8));
 	return (char*)array;
 }


### PR DESCRIPTION
This PR fixes an issue with the frida-go bindings for the latest Frida version (16.3.3) and the latest MacOS (14.5 (23F79)). This fixes #35