### PR TITLE
Link with Security Framework

### DIFF
--- a/frida/frida.go
+++ b/frida/frida.go
@@ -9,7 +9,7 @@ package frida
 /*
 #cgo LDFLAGS: -lfrida-core -lm -ldl
 #cgo CFLAGS: -I/usr/local/include/ -w
-#cgo darwin LDFLAGS: -lbsm -framework IOKit -framework Foundation -framework AppKit -lpthread
+#cgo darwin LDFLAGS: -lbsm -framework IOKit -framework Foundation -framework AppKit -framework Security -lpthread
 #cgo darwin CFLAGS: -Wno-error=incompatible-function-pointer-types
 #cgo android LDFLAGS: -llog
 #cgo android CFLAGS: -DANDROID -Wno-error=incompatible-function-pointer-types


### PR DESCRIPTION
I noticed that the current frida core devkit would not allow for frida-go to build with the error:

```
/usr/local/go/pkg/tool/darwin_arm64/link: running clang failed: exit status 1
Undefined symbols for architecture arm64:
  "_SecTaskCopyValueForEntitlement", referenced from:
      _darwin_detach_kernel_driver in libfrida-core.a[474](libusb_os_darwin_usb.c.o)
  "_SecTaskCreateFromSelf", referenced from:
      _darwin_detach_kernel_driver in libfrida-core.a[474](libusb_os_darwin_usb.c.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

After some research this is due to a change that now requires the Security framework. See https://github.com/frida/frida/issues/2910

Doing that change locally fixed my build issues.