### PR TITLE
update rpc call

### DIFF
--- a/frida/script.go
+++ b/frida/script.go
@@ -89,6 +89,7 @@ func (s *Script) DisableDebugger() error {
 // ExportsCall will try to call fn from the rpc.exports with args provided
 func (s *Script) ExportsCall(fn string, args ...any) any {
 	ch := s.makeExportsCall(fn, args...)
+	defer releaseChannel(ch)
 	ret := <-ch
 	return ret
 }
@@ -96,19 +97,14 @@ func (s *Script) ExportsCall(fn string, args ...any) any {
 // ExportsCallWithContext will try to call fn from the rpc.exports with args provided using context provided.
 func (s *Script) ExportsCallWithContext(ctx context.Context, fn string, args ...any) any {
 	ch := s.makeExportsCall(fn, args...)
-
-	for {
-		select {
-		case <-ctx.Done():
-			// because the context is done, we still need to read from the channel
-			go func() {
-				<-ch
-			}()
-			return ErrContextCancelled
-		case ret := <-ch:
-			return ret
-		}
+	defer releaseChannel(ch)
+	select {
+	case <-ctx.Done():
+		return ErrContextCancelled
+	case ret := <-ch:
+		return ret
 	}
+
 }
 
 // Clean will clean the resources held by the script.
@@ -169,7 +165,7 @@ func (s *Script) hijackFn(message string, data []byte) {
 		}
 		ch := callerCh.(chan any)
 		ch <- ret
-		close(ch)
+		rpcCalls.Delete(rpcID)
 
 	} else {
 		var args []reflect.Value
@@ -214,11 +210,36 @@ func (s *Script) makeExportsCall(fn string, args ...any) chan any {
 		rpc[ct] = aIface
 	}
 
-	ch := make(chan any)
+	ch := getChannel()
 	rpcCalls.Store(rpcData[1], ch)
 
 	bt, _ := json.Marshal(rpc)
 	s.Post(string(bt), nil)
 
 	return ch
+}
+
+var channelPool = sync.Pool{
+	New: func() interface{} {
+		return make(chan any, 1)
+	},
+}
+
+func getChannel() chan any {
+	ch := channelPool.Get().(chan any)
+	select {
+	case <-ch:
+	default:
+	}
+
+	return ch
+}
+
+func releaseChannel(ch chan any) {
+	select {
+	case <-ch:
+	default:
+
+	}
+	channelPool.Put(ch)
 }

--- a/frida/script.go
+++ b/frida/script.go
@@ -104,7 +104,6 @@ func (s *Script) ExportsCallWithContext(ctx context.Context, fn string, args ...
 	case ret := <-ch:
 		return ret
 	}
-
 }
 
 // Clean will clean the resources held by the script.
@@ -166,7 +165,6 @@ func (s *Script) hijackFn(message string, data []byte) {
 		ch := callerCh.(chan any)
 		ch <- ret
 		rpcCalls.Delete(rpcID)
-
 	} else {
 		var args []reflect.Value
 		switch s.fn.Type().NumIn() {
@@ -239,7 +237,6 @@ func releaseChannel(ch chan any) {
 	select {
 	case <-ch:
 	default:
-
 	}
 	channelPool.Put(ch)
 }


### PR DESCRIPTION
I found some issues when calling the RPC method of JS through high concurrency

- Due to `rpcCalls` not calling the `Delete` method, function calls will continue to increase memory usage
- By analyzing through pprof, `ch:=make (chan any)` will continue to open up memory

So I tried to optimize the above two points

English is not my native language; please excuse typing errors.