### PR TITLE
feat: support for Windows (using MinGW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported OS:
 - [x] MacOS
 - [x] Linux
 - [x] Android
-- [ ] Windows
+- [x] Windows
 
 # Small example
 ```golang

--- a/frida/frida.go
+++ b/frida/frida.go
@@ -7,8 +7,11 @@
 package frida
 
 /*
-#cgo LDFLAGS: -lfrida-core -lm -ldl
+#cgo LDFLAGS: -lfrida-core -lm
+#cgo !windows LDFLAGS: -ldl
+#cgo windows LDFLAGS: -lws2_32 -lgdi32 -lole32 -liphlpapi -lsetupapi -lpsapi -lshell32 -lshlwapi -ldnsapi -lcrypt32 -luuid -lshfolder
 #cgo CFLAGS: -I/usr/local/include/ -w
+#cgo windows CFLAGS: -Wno-error=incompatible-pointer-types
 #cgo darwin LDFLAGS: -lbsm -framework IOKit -framework Foundation -framework AppKit -framework Security -lpthread
 #cgo darwin CFLAGS: -Wno-error=incompatible-function-pointer-types
 #cgo android LDFLAGS: -llog

--- a/frida/unmarshaller.go
+++ b/frida/unmarshaller.go
@@ -1,10 +1,20 @@
 package frida
 
 /*
+#ifdef _WIN32
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #pragma comment(lib, "Ws2_32.lib")
+	typedef unsigned short in_port_t;
+#else
+    #include <sys/socket.h>
+    #include <netinet/in.h>
+    #include <arpa/inet.h>
+#endif
+
 #include <frida-core.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
 
 static char * get_gvalue_gtype(GValue * val) {
 	return (char*)(G_VALUE_TYPE_NAME(val));

--- a/frida/unmarshaller.go
+++ b/frida/unmarshaller.go
@@ -13,8 +13,6 @@ package frida
 #endif
 
 #include <frida-core.h>
-#include <stdlib.h>
-#include <string.h>
 
 static char * get_gvalue_gtype(GValue * val) {
 	return (char*)(G_VALUE_TYPE_NAME(val));


### PR DESCRIPTION
1. This is a very preliminary attempt. I successfully built it using GCC version 14.2.0 (Rev1, Built by the MSYS2 project), and it works on my machine.
2. Currently, On Windows, `cgo` only supports MinGW, and support for MSVC is still in progress (ref: https://github.com/golang/go/issues/20982), so we **have to use MinGW.**
3. Although the upstream project (https://github.com/frida/frida-core) has a build action workflow for Windows-MinGW, there is no `frida-core-devkit` for Windows-MinGW in the releases at https://github.com/frida/frida/releases. This means users need to manually build the `frida-core-devkit` for Windows-MinGW from source code. (**Note: I’m not sure why this is the case.**)
4. Noticing that CI/CD includes testing, based on point 3, it seems challenging to integrate testing for the Windows platform into CI/CD (due to the absence of a `frida-core-devkit` for Windows-MinGW in https://github.com/frida/frida/releases).
5. Clearly, most of the examples in the documentation are designed specifically for Unix systems. If needed, I can provide alternative examples for the Windows platform.