### PR TITLE
fix(frida): return correct variable in DeviceByID (closes #65)

### DIFF
--- a/frida/frida.go
+++ b/frida/frida.go
@@ -95,7 +95,7 @@ func DeviceByID(id string) (*Device, error) {
 			return nil, err
 		}
 		data.Store(id, dev)
-		return v.(*Device), nil
+		return dev.(*Device), nil
 	}
 	return v.(*Device), nil
 }


### PR DESCRIPTION
Fix for `frida.DeviceByID` returning `nil` device (with 100% reliability).

The method was found in use by [ipsw](https://github.com/blacktop/ipsw) (apparently the related code path was never tested).



