### PR TITLE
Add Exceptor option to session options

### DIFF
--- a/frida/session_options.go
+++ b/frida/session_options.go
@@ -30,6 +30,11 @@ func (s *SessionOptions) PersistTimeout() int {
 	return int(C.frida_session_options_get_persist_timeout(s.opts))
 }
 
+// Sets Frida's exception handling mode.
+func (s *SessionOptions) SetExceptor(exceptor Exceptor) {
+	C.frida_session_options_set_exceptor(s.opts, C.FridaExceptor(exceptor))
+}
+
 // Clean will clean the resources held by the session options.
 func (s *SessionOptions) Clean() {
 	clean(unsafe.Pointer(s.opts), unrefFrida)

--- a/frida/types.go
+++ b/frida/types.go
@@ -249,3 +249,17 @@ func (g GadgetBreakpointAction) String() string {
 type GBytesWrapper struct {
 	ptr *C.GBytes
 }
+
+type Exceptor int
+
+const (
+	ExceptorFull Exceptor = iota
+	ExceptorHandlerOnly
+	ExceptorOff
+)
+
+func (e Exceptor) String() string {
+	return [...]string{"full",
+		"handler-only",
+		"off"}[e]
+}


### PR DESCRIPTION
Adds a simple SetExceptor function that was (sort of) recently exposed in Frida. 

I didn't want to break the current signature of the New func so I simply added a Set function instead, like there already is for other option structs.

Happy to change it to match whatever form you'd like it to be though.