### PR TITLE
Update linting to use same frida version as examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,11 +14,11 @@ jobs:
           - runs_on: ubuntu-latest
             arch: x86_64
             os: linux
-            frida_version: "17.15.3"
+            frida_version: "17.15.5"
           - runs_on: macos-latest
             arch: arm64
             os: macos
-            frida_version: "17.15.3"
+            frida_version: "17.15.5"
     runs-on: ${{ matrix.runs_on }}
     env:
       GOEXPERIMENT: cgocheck2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         arch: [x86_64]
         os: [linux]
-        frida_version: ["17.6.1"]
+        frida_version: ["17.15.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         arch: [x86_64]
         os: [linux]
-        frida_version: ["17.15.3"]
+        frida_version: ["17.15.5"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/frida/session_options.go
+++ b/frida/session_options.go
@@ -30,7 +30,7 @@ func (s *SessionOptions) PersistTimeout() int {
 	return int(C.frida_session_options_get_persist_timeout(s.opts))
 }
 
-// Sets Frida's exception handling mode.
+// SetExceptor sets Frida's exception handling mode.
 func (s *SessionOptions) SetExceptor(exceptor Exceptor) {
 	C.frida_session_options_set_exceptor(s.opts, C.FridaExceptor(exceptor))
 }


### PR DESCRIPTION
I noticed that the linting jobs failed are failing, because it uses an older Frida version. I've aligned all jobs with the latest Frida version 17.15.5.

Also fixed my comment to pass static check. 